### PR TITLE
Constrain media images to their container

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -84,6 +84,7 @@ const handleImageError = (event) => {
 .media img {
   min-width: 0;
   width: 100%;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;


### PR DESCRIPTION
### Motivation
- Large images placed in the `.media` area could overflow the card and break layout, so images should be constrained to fit the container while preserving aspect ratio.

### Description
- Add `height: 100%` to `.media img` in `src/components/Item.vue` so images fill the container height and are kept within bounds via the existing `object-fit: contain` rule.

### Testing
- Started the dev server with `npm run serve` which launched Vite successfully, attempted an automated Playwright screenshot which failed due to the headless browser crashing in this environment, and an earlier `npm run dev` attempt failed because that script is not defined.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b3eed76b8832faf87ac618ea6c47e)