### PR TITLE
Remove unused media wrapper and simplify image styles

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -89,6 +89,7 @@ const handleImageError = (event) => {
 .media img {
   width: 100%;
   height: auto;
+  max-height: 40cqh;
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -87,7 +87,7 @@ const handleImageError = (event) => {
 }
 
 .media img {
-  width: auto;
+  width: 100%;
   height: auto;
   max-height: 40cqh;
   max-width: 99cqh;

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -87,9 +87,10 @@ const handleImageError = (event) => {
 }
 
 .media img {
-  width: 100%;
+  width: auto;
   height: auto;
   max-height: 40cqh;
+  max-width: 99cqh;
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -68,6 +68,7 @@ const handleImageError = (event) => {
   overflow: hidden;
   display: grid;
   gap: 12px;
+  container-type: size;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -86,6 +87,7 @@ const handleImageError = (event) => {
 .media img {
   width: 100%;
   height: auto;
+  max-height: 40cqh;
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -80,8 +80,11 @@ const handleImageError = (event) => {
 .media {
   display: block;
   background: #f8fafc;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
   width: 100%;
   box-sizing: border-box;
+  min-height: 0;
 }
 
 .media img {

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -88,9 +88,8 @@ const handleImageError = (event) => {
 
 .media img {
   width: 100%;
-  height: auto;
-  max-height: 40cqh;
-  max-width: 99cqh;
+  height: 100%;
+  object-fit: cover;       /* 画像を枠にフィット */
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -68,7 +68,6 @@ const handleImageError = (event) => {
   overflow: hidden;
   display: grid;
   gap: 12px;
-  container-type: size;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -90,7 +89,6 @@ const handleImageError = (event) => {
 .media img {
   width: 100%;
   height: auto;
-  max-height: 40cqh;
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -69,6 +69,8 @@ const handleImageError = (event) => {
   display: grid;
   gap: 12px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  grid-template-rows: auto 1fr;
+  height: 100%;
 }
 
 .card:hover {
@@ -78,12 +80,13 @@ const handleImageError = (event) => {
 
 .media {
   aspect-ratio: 4 / 3;
+  overflow: hidden;
 }
 
 .media img {
   width: 100%;
   height: 100%;
-  object-fit: cover;       /* 画像を枠にフィット */
+  object-fit: cover; 
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -1,16 +1,14 @@
 <template>
   <article class="card">
     <a :href="url" class="media" target="_blank" rel="noopener">
-      <span class="media-inner">
-        <img
-          :src="resolvedImage"
-          :alt="title"
-          loading="lazy"
-          decoding="async"
-          fetchpriority="low"
-          @error="handleImageError"
-        />
-      </span>
+      <img
+        :src="resolvedImage"
+        :alt="title"
+        loading="lazy"
+        decoding="async"
+        fetchpriority="low"
+        @error="handleImageError"
+      />
     </a>
     <div class="card-body">
       <div class="meta">
@@ -81,31 +79,13 @@ const handleImageError = (event) => {
 .media {
   display: block;
   background: #f8fafc;
-  aspect-ratio: 4 / 3;
-  overflow: hidden;
   width: 100%;
   box-sizing: border-box;
-  min-height: 0;
-}
-
-.media-inner {
-  width: 100%;
-  height: 100%;
-  padding: 12px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .media img {
-  min-width: 0;
-  min-height: 0;
-  width: auto;
-  max-width: 100%;
+  width: 100%;
   height: auto;
-  max-height: 100%;
-  object-fit: contain;
   display: block;
 }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -77,13 +77,7 @@ const handleImageError = (event) => {
 }
 
 .media {
-  display: block;
-  background: #f8fafc;
   aspect-ratio: 4 / 3;
-  overflow: hidden;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: 0;
 }
 
 .media img {


### PR DESCRIPTION
### Motivation
- Remove the redundant `.media-inner` wrapper that added DOM complexity but provided no benefit. 
- Ensure oversized images render reliably inside item cards by simplifying layout and CSS. 
- Replace previous aspect-ratio/overflow and flex-centering hacks with a straightforward responsive image rule.

### Description
- Delete the `<span class="media-inner">` wrapper from the template and render the `<img>` directly inside the `.media` link. 
- Remove the `.media-inner` CSS block and drop `aspect-ratio`, `overflow`, `min-height`, inner padding, and flex-centering from `.media`. 
- Simplify image styling to `.media img { width: 100%; height: auto; display: block; }` and keep `.media` as a simple block-level container with background and box-sizing.

### Testing
- Ran `npm run serve -- --host 0.0.0.0 --port 4173` which started Vite successfully and served the app at the local and network URLs. 
- Executed a Playwright script that navigated to the served app and saved a screenshot to `artifacts/items-simple.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b6d98a7fc832f890482e0f5b220fb)