### PR TITLE
Add OGP tags and automated image generation

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Build
         run: npm run build --if-present
 
+      - name: Generate OGP Image from GAS JSON
+        run: |
+          # URL-encoded title: ミニマリストの持ち物リスト -> %E3%83%9F%E3%83%8B%E3%83%9E%E3%83%AA%E3%82%B9%E3%83%88%E3%81%AE%E6%8C%81%E3%81%A1%E7%89%A9%E3%83%AA%E3%82%B9%E3%83%88
+          JSON_RESPONSE=$(curl -L -s "https://script.google.com/macros/s/AKfycbzbMAKxkzHlwN8SY7ygJA34xYESMNNdkGNt8vv1XMcZSksgHsUwOxCCdP-wgg6fv7M/exec?t=%E3%83%9F%E3%83%8B%E3%83%9E%E3%83%AA%E3%82%B9%E3%83%88%E3%81%AE%E6%8C%81%E3%81%A1%E7%89%A9%E3%83%AA%E3%82%B9%E3%83%88")
+          echo $JSON_RESPONSE | jq -r '.png' | base64 -d > ./dist/ogp.png
+          ls -lh ./dist/ogp.png
+
       - name: "Deploy to gh-pages 🚀"
         uses: JamesIves/github-pages-deploy-action@releases/v3
         if: ${{ matrix.node-version == '22.x' }}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="ミニマリストになりたい40代サラリーマンの持ち物リスト" />
     <title>ミニマリストの持ち物リスト</title>
+    <meta property="og:title" content="ミニマリストの持ち物リスト" />
+    <meta property="og:description" content="ミニマリストになりたい40代サラリーマンの持ち物リスト" />
+    <meta property="og:image" content="https://freddiefujiwara.com/list-of-stuff/ogp.png" />
+    <meta property="og:url" content="https://freddiefujiwara.com/list-of-stuff/" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
This change adds Open Graph Protocol (OGP) support to the project.
1. Updated `index.html` with relevant OGP meta tags for better social media sharing.
2. Modified the GitHub Actions workflow (`node.js.yml`) to include a step that fetches a generated OGP image from a Google Apps Script endpoint and saves it to the `dist` directory before deployment.
3. The OGP image generation URL was adapted to use the project's title "ミニマリストの持ち物リスト".

---
*PR created automatically by Jules for task [16698425088762803197](https://jules.google.com/task/16698425088762803197) started by @freddiefujiwara*