### PR TITLE
Add copy-to-clipboard functionality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,8 @@ const { activeGenre, error, filteredItems, genres, loading, toggleGenre } = useI
 const showCopyMessage = ref(false)
 const copyToClipboard = async () => {
   try {
-    const json = JSON.stringify(filteredItems.value, null, 2)
+    const dataToCopy = filteredItems.value.map(({ image, url, ...rest }) => rest)
+    const json = JSON.stringify(dataToCopy, null, 2)
     await navigator.clipboard.writeText(json)
     showCopyMessage.value = true
     setTimeout(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
         >
           {{ genre }}
         </button>
-        <button type="button" class="btn-copy" @click="copyToClipboard">
+        <button type="button" class="btn-copy" :disabled="loading" @click="copyToClipboard">
           {{ showCopyMessage ? 'コピー完了' : 'コピー' }}
         </button>
       </div>
@@ -125,9 +125,15 @@ h1 {
   transition: all 0.2s;
 }
 
-.btn-copy:hover {
+.btn-copy:hover:not(:disabled) {
   background: #0ea5e9;
   color: #ffffff;
+}
+
+.btn-copy:disabled {
+  border-color: #cbd5e1;
+  color: #cbd5e1;
+  cursor: not-allowed;
 }
 
 .content {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,9 @@
         >
           {{ genre }}
         </button>
+        <button type="button" class="btn-copy" @click="copyToClipboard">
+          {{ showCopyMessage ? 'コピー完了' : 'コピー' }}
+        </button>
       </div>
     </header>
 
@@ -39,11 +42,26 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import Item from '@/components/Item.vue'
 import { API_URL } from '@/constants/app'
 import { useItems } from '@/composables/useItems'
 
 const { activeGenre, error, filteredItems, genres, loading, toggleGenre } = useItems(API_URL)
+
+const showCopyMessage = ref(false)
+const copyToClipboard = async () => {
+  try {
+    const json = JSON.stringify(filteredItems.value, null, 2)
+    await navigator.clipboard.writeText(json)
+    showCopyMessage.value = true
+    setTimeout(() => {
+      showCopyMessage.value = false
+    }, 2000)
+  } catch (err) {
+    console.error('Failed to copy:', err)
+  }
+}
 </script>
 
 <style scoped>
@@ -93,6 +111,23 @@ h1 {
 .chip.active {
   background: #0ea5e9;
   color: #f8fafc;
+}
+
+.btn-copy {
+  border: 1px solid #0ea5e9;
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: transparent;
+  color: #0ea5e9;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.btn-copy:hover {
+  background: #0ea5e9;
+  color: #ffffff;
 }
 
 .content {

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -42,6 +42,8 @@ describe('App.vue', async () => {
     const wrapper = mount(App)
 
     expect(wrapper.text()).toContain('読み込み中です…')
+    const copyButton = wrapper.find('.btn-copy')
+    expect(copyButton.element.disabled).toBe(true)
   })
 
   it('displays an error message if the data fetch fails', async () => {
@@ -65,6 +67,8 @@ describe('App.vue', async () => {
 
     expect(mockShuffleItems).toHaveBeenCalledWith(mockItems)
     expect(wrapper.findAllComponents({ name: 'GearItemCard' }).length).toBe(mockItems.length)
+    const copyButton = wrapper.find('.btn-copy')
+    expect(copyButton.element.disabled).toBe(false)
   })
 
   it('filters the list of items when a genre is clicked', async () => {

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -93,4 +93,70 @@ describe('App.vue', async () => {
 
     expect(wrapper.findAllComponents({ name: 'GearItemCard' }).length).toBe(mockItems.length)
   })
+
+  it('copies filtered items to clipboard when copy button is clicked', async () => {
+    const mockItems = buildItems()
+    mockFetchResolve(mockItems)
+    const writeTextSpy = vi.fn().mockResolvedValue()
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextSpy,
+      },
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    const copyButton = wrapper.find('.btn-copy')
+    await copyButton.trigger('click')
+
+    expect(writeTextSpy).toHaveBeenCalledWith(JSON.stringify(mockItems, null, 2))
+    expect(wrapper.text()).toContain('コピー完了')
+  })
+
+  it('shows copy completion message temporarily', async () => {
+    vi.useFakeTimers()
+    const mockItems = buildItems()
+    mockFetchResolve(mockItems)
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(),
+      },
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    const copyButton = wrapper.find('.btn-copy')
+    await copyButton.trigger('click')
+
+    expect(wrapper.text()).toContain('コピー完了')
+
+    vi.advanceTimersByTime(2000)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).not.toContain('コピー完了')
+    expect(wrapper.text()).toContain('コピー')
+    vi.useRealTimers()
+  })
+
+  it('logs error when clipboard copy fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockItems = buildItems()
+    mockFetchResolve(mockItems)
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Copy failed')),
+      },
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    const copyButton = wrapper.find('.btn-copy')
+    await copyButton.trigger('click')
+
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to copy:', expect.any(Error))
+    consoleSpy.mockRestore()
+  })
 })

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -12,9 +12,9 @@ vi.mock('@/utils/items', async (importOriginal) => {
 })
 
 const buildItems = () => [
-  { title: 'A', genre: 'Gear', price: 1000 },
-  { title: 'B', genre: 'Food', price: 2500 },
-  { title: 'C', genre: 'Gear', price: 4200 },
+  { title: 'A', genre: 'Gear', price: 1000, image: 'a.jpg', url: 'https://a.com' },
+  { title: 'B', genre: 'Food', price: 2500, image: 'b.jpg', url: 'https://b.com' },
+  { title: 'C', genre: 'Gear', price: 4200, image: 'c.jpg', url: 'https://c.com' },
 ]
 
 const mockFetchResolve = (items) => {
@@ -98,7 +98,7 @@ describe('App.vue', async () => {
     expect(wrapper.findAllComponents({ name: 'GearItemCard' }).length).toBe(mockItems.length)
   })
 
-  it('copies filtered items to clipboard when copy button is clicked', async () => {
+  it('copies filtered items to clipboard (excluding image and url) when copy button is clicked', async () => {
     const mockItems = buildItems()
     mockFetchResolve(mockItems)
     const writeTextSpy = vi.fn().mockResolvedValue()
@@ -114,7 +114,8 @@ describe('App.vue', async () => {
     const copyButton = wrapper.find('.btn-copy')
     await copyButton.trigger('click')
 
-    expect(writeTextSpy).toHaveBeenCalledWith(JSON.stringify(mockItems, null, 2))
+    const expectedData = mockItems.map(({ image, url, ...rest }) => rest)
+    expect(writeTextSpy).toHaveBeenCalledWith(JSON.stringify(expectedData, null, 2))
     expect(wrapper.text()).toContain('コピー完了')
   })
 


### PR DESCRIPTION
This PR adds a "Copy" button to the web UI, allowing users to copy the current list of items (after filtering) as a formatted JSON string to their clipboard. 

Key changes:
- Modified `src/App.vue` to include the Copy button and associated logic.
- Updated `tests/unit/App.spec.js` to ensure the new functionality is correctly tested and maintains 100% coverage.
- Visually verified the UI changes using Playwright.

---
*PR created automatically by Jules for task [16935676011326151625](https://jules.google.com/task/16935676011326151625) started by @freddiefujiwara*